### PR TITLE
Refactor remove html loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,5 @@
-<div align="center">
-  <a href="https://github.com/webpack/webpack">
-    <img width="200" height="200" src="https://webpack.js.org/assets/icon-square-big.svg">
-  </a>
-</div>
-
-[![npm][npm]][npm-url]
-[![node][node]][node-url]
-[![deps][deps]][deps-url]
-[![tests][tests]][tests-url]
-[![cover][cover]][cover-url]
-[![chat][chat]][chat-url]
-[![size][size]][size-url]
+[![NPM Version][10]][8]
+[![Standard Version][11]][9]
 
 # Remark Loader
 
@@ -59,15 +48,9 @@ This project was inspired the following open source work:
 - [`react-markdown-loader`][6]
 - [`marksy`][7]
 
-## Contributing
-
-Please take a moment to read our contributing guidelines if you haven't yet done so.
-
-[CONTRIBUTING](./.github/CONTRIBUTING.md)
-
 ## License
 
-[MIT](./LICENSE)
+MIT (c) 2017
 
 [1]: https://github.com/wooorm/remark/blob/master/doc/plugins.md
 [2]: https://github.com/skipjack/remark-loader/issues
@@ -81,17 +64,3 @@ Please take a moment to read our contributing guidelines if you haven't yet done
 [10]: https://img.shields.io/npm/v/remark-loader.svg
 [11]: https://img.shields.io/badge/release-standard%20version-brightgreen.svg
 [12]: https://mdxjs.com/
-[npm]: https://img.shields.io/npm/v/remark-loader.svg
-[npm-url]: https://npmjs.com/package/remark-loader
-[node]: https://img.shields.io/node/v/remark-loader.svg
-[node-url]: https://nodejs.org
-[deps]: https://david-dm.org/webpack-contrib/remark-loader.svg
-[deps-url]: https://david-dm.org/webpack-contrib/remark-loader
-[tests]: https://github.com/webpack-contrib/remark-loader/workflows/remark-loader/badge.svg
-[tests-url]: https://github.com/webpack-contrib/remark-loader/actions
-[cover]: https://codecov.io/gh/webpack-contrib/remark-loader/branch/master/graph/badge.svg
-[cover-url]: https://codecov.io/gh/webpack-contrib/remark-loader
-[chat]: https://img.shields.io/badge/gitter-webpack%2Fwebpack-brightgreen.svg
-[chat-url]: https://gitter.im/webpack/webpack
-[size]: https://packagephobia.now.sh/badge?p=remark-loader
-[size-url]: https://packagephobia.now.sh/result?p=remark-loader

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
-[![NPM Version][10]][8]
-[![Standard Version][11]][9]
+<div align="center">
+  <a href="https://github.com/webpack/webpack">
+    <img width="200" height="200" src="https://webpack.js.org/assets/icon-square-big.svg">
+  </a>
+</div>
+
+[![npm][npm]][npm-url]
+[![node][node]][node-url]
+[![deps][deps]][deps-url]
+[![tests][tests]][tests-url]
+[![cover][cover]][cover-url]
+[![chat][chat]][chat-url]
+[![size][size]][size-url]
 
 # Remark Loader
 
@@ -48,9 +59,15 @@ This project was inspired the following open source work:
 - [`react-markdown-loader`][6]
 - [`marksy`][7]
 
+## Contributing
+
+Please take a moment to read our contributing guidelines if you haven't yet done so.
+
+[CONTRIBUTING](./.github/CONTRIBUTING.md)
+
 ## License
 
-MIT (c) 2017
+[MIT](./LICENSE)
 
 [1]: https://github.com/wooorm/remark/blob/master/doc/plugins.md
 [2]: https://github.com/skipjack/remark-loader/issues
@@ -64,3 +81,17 @@ MIT (c) 2017
 [10]: https://img.shields.io/npm/v/remark-loader.svg
 [11]: https://img.shields.io/badge/release-standard%20version-brightgreen.svg
 [12]: https://mdxjs.com/
+[npm]: https://img.shields.io/npm/v/remark-loader.svg
+[npm-url]: https://npmjs.com/package/remark-loader
+[node]: https://img.shields.io/node/v/remark-loader.svg
+[node-url]: https://nodejs.org
+[deps]: https://david-dm.org/webpack-contrib/remark-loader.svg
+[deps-url]: https://david-dm.org/webpack-contrib/remark-loader
+[tests]: https://github.com/webpack-contrib/remark-loader/workflows/remark-loader/badge.svg
+[tests-url]: https://github.com/webpack-contrib/remark-loader/actions
+[cover]: https://codecov.io/gh/webpack-contrib/remark-loader/branch/master/graph/badge.svg
+[cover-url]: https://codecov.io/gh/webpack-contrib/remark-loader
+[chat]: https://img.shields.io/badge/gitter-webpack%2Fwebpack-brightgreen.svg
+[chat-url]: https://gitter.im/webpack/webpack
+[size]: https://packagephobia.now.sh/badge?p=remark-loader
+[size-url]: https://packagephobia.now.sh/result?p=remark-loader

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
 import { getOptions } from 'loader-utils';
-import HTMLLoader from 'html-loader';
 import validateOptions from 'schema-utils';
 
 import parse from './parse';
@@ -22,11 +21,6 @@ export default function loader(content) {
   parse(content, options)
     // @todo we should probably just intercept images in the tree
     // or recommend that the `html-loader` be chained
-    .then((processed) =>
-      Object.assign({}, processed, {
-        content: HTMLLoader(processed.content),
-      })
-    )
     .then((resolved) => callback(null, resolved.content))
     .catch(callback);
 }

--- a/src/parse.js
+++ b/src/parse.js
@@ -1,6 +1,5 @@
 import FrontMatter from 'front-matter';
 import Remark from 'remark';
-import RemarkHTML from 'remark-html';
 import Report from 'vfile-reporter';
 
 /**
@@ -23,7 +22,6 @@ export default function parse(markdown, options) {
 
         return remark.use(item);
       }, Remark())
-      .use(RemarkHTML)
       .process(parsed.body, (err, file) => {
         const result = {
           content: file.contents,

--- a/test/__snapshots__/loader.test.js.snap
+++ b/test/__snapshots__/loader.test.js.snap
@@ -1,7 +1,235 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`loader should work: errors 1`] = `Array []`;
+exports[`loader should work markdown -> html: errors 1`] = `Array []`;
 
-exports[`loader should work: md 1`] = `"module.exports = \\"<h1>h1 Heading 8-)</h1>\\\\n<h2>h2 Heading</h2>\\\\n<h3>h3 Heading</h3>\\\\n<h4>h4 Heading</h4>\\\\n<h5>h5 Heading</h5>\\\\n<h6>h6 Heading</h6>\\\\n<h2>Horizontal Rules</h2>\\\\n<hr>\\\\n<hr>\\\\n<hr>\\\\n<h2>Typographic replacements</h2>\\\\n<p>Enable typographer option to see result.</p>\\\\n<p>(c) (C) (r) (R) (tm) (TM) (p) (P) +-</p>\\\\n<p>test.. test... test..... test?..... test!....</p>\\\\n<p>!!!!!! ???? ,,  -- ---</p>\\\\n<p>\\\\\\"Smartypants, double quotes\\\\\\" and 'single quotes'</p>\\\\n<h2>Emphasis</h2>\\\\n<p><strong>This is bold text</strong></p>\\\\n<p><strong>This is bold text</strong></p>\\\\n<p><em>This is italic text</em></p>\\\\n<p><em>This is italic text</em></p>\\\\n<p><del>Strikethrough</del></p>\\\\n<h2>Blockquotes</h2>\\\\n<blockquote>\\\\n<p>Blockquotes can also be nested...</p>\\\\n<blockquote>\\\\n<p>...by using additional greater-than signs right next to each other...</p>\\\\n<blockquote>\\\\n<p>...or with spaces between arrows.</p>\\\\n</blockquote>\\\\n</blockquote>\\\\n</blockquote>\\\\n<h2>Lists</h2>\\\\n<p>Unordered</p>\\\\n<ul>\\\\n<li>Create a list by starting a line with <code>+</code>, <code>-</code>, or <code>*</code></li>\\\\n<li>Sub-lists are made by indenting 2 spaces:<ul>\\\\n<li>Marker character change forces new list start:<ul>\\\\n<li>Ac tristique libero volutpat at</li>\\\\n</ul><ul>\\\\n<li>Facilisis in pretium nisl aliquet</li>\\\\n</ul><ul>\\\\n<li>Nulla volutpat aliquam velit</li>\\\\n</ul></li>\\\\n</ul></li>\\\\n<li>Very easy!</li>\\\\n</ul>\\\\n<p>Ordered</p>\\\\n<ol>\\\\n<li>Lorem ipsum dolor sit amet</li>\\\\n<li>Consectetur adipiscing elit</li>\\\\n<li>Integer molestie lorem at massa</li>\\\\n</ol>\\\\n<ol>\\\\n<li>You can use sequential numbers...</li>\\\\n<li>...or keep all the numbers as <code>1.</code></li>\\\\n</ol>\\\\n<p>Start numbering with offset:</p>\\\\n<ol start=\\\\\\"57\\\\\\">\\\\n<li>foo</li>\\\\n<li>bar</li>\\\\n</ol>\\\\n<h2>Code</h2>\\\\n<p>Inline <code>code</code></p>\\\\n<p>Indented code</p>\\\\n<pre><code>// Some comments\\\\nline 1 of code\\\\nline 2 of code\\\\nline 3 of code\\\\n</code></pre>\\\\n<p>Block code \\\\\\"fences\\\\\\"</p>\\\\n<pre><code>Sample text here...\\\\n</code></pre>\\\\n<p>Syntax highlighting</p>\\\\n<pre><code class=\\\\\\"language-js\\\\\\">var foo = function (bar) {\\\\n  return bar++;\\\\n};\\\\n\\\\nconsole.log(foo(5));\\\\n</code></pre>\\\\n<h2>Tables</h2>\\\\n<table>\\\\n<thead>\\\\n<tr>\\\\n<th>Option</th>\\\\n<th>Description</th>\\\\n</tr>\\\\n</thead>\\\\n<tbody>\\\\n<tr>\\\\n<td>data</td>\\\\n<td>path to data files to supply the data that will be passed into templates.</td>\\\\n</tr>\\\\n<tr>\\\\n<td>engine</td>\\\\n<td>engine to be used for processing templates. Handlebars is the default.</td>\\\\n</tr>\\\\n<tr>\\\\n<td>ext</td>\\\\n<td>extension to be used for dest files.</td>\\\\n</tr>\\\\n</tbody>\\\\n</table>\\\\n<p>Right aligned columns</p>\\\\n<table>\\\\n<thead>\\\\n<tr>\\\\n<th align=\\\\\\"right\\\\\\">Option</th>\\\\n<th align=\\\\\\"right\\\\\\">Description</th>\\\\n</tr>\\\\n</thead>\\\\n<tbody>\\\\n<tr>\\\\n<td align=\\\\\\"right\\\\\\">data</td>\\\\n<td align=\\\\\\"right\\\\\\">path to data files to supply the data that will be passed into templates.</td>\\\\n</tr>\\\\n<tr>\\\\n<td align=\\\\\\"right\\\\\\">engine</td>\\\\n<td align=\\\\\\"right\\\\\\">engine to be used for processing templates. Handlebars is the default.</td>\\\\n</tr>\\\\n<tr>\\\\n<td align=\\\\\\"right\\\\\\">ext</td>\\\\n<td align=\\\\\\"right\\\\\\">extension to be used for dest files.</td>\\\\n</tr>\\\\n</tbody>\\\\n</table>\\\\n<h2>Links</h2>\\\\n<p><a href=\\\\\\"http://dev.nodeca.com\\\\\\">link text</a></p>\\\\n<p><a href=\\\\\\"http://nodeca.github.io/pica/demo/\\\\\\" title=\\\\\\"title text!\\\\\\">link with title</a></p>\\\\n<p>Autoconverted link <a href=\\\\\\"https://github.com/nodeca/pica\\\\\\">https://github.com/nodeca/pica</a> (enable linkify to see)</p>\\\\n<h2>Images</h2>\\\\n<p><img src=\\\\\\"https://octodex.github.com/images/minion.png\\\\\\" alt=\\\\\\"Minion\\\\\\">\\\\n<img src=\\\\\\"https://octodex.github.com/images/stormtroopocat.jpg\\\\\\" alt=\\\\\\"Stormtroopocat\\\\\\" title=\\\\\\"The Stormtroopocat\\\\\\"></p>\\\\n<p>Like links, Images also have a footnote style syntax</p>\\\\n<p><img src=\\\\\\"https://octodex.github.com/images/dojocat.jpg\\\\\\" alt=\\\\\\"Alt text\\\\\\" title=\\\\\\"The Dojocat\\\\\\"></p>\\\\n<p>With a reference later in the document defining the URL location:</p>\\\\n<h2>Plugins</h2>\\\\n<p>The killer feature of <code>markdown-it</code> is very effective support of\\\\n<a href=\\\\\\"https://www.npmjs.org/browse/keyword/markdown-it-plugin\\\\\\">syntax plugins</a>.</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-emoji\\\\\\">Emojies</a></h3>\\\\n<blockquote>\\\\n<p>Classic markup: :wink: :crush: :cry: :tear: :laughing: :yum:</p>\\\\n<p>Shortcuts (emoticons): :-) :-( 8-) ;)</p>\\\\n</blockquote>\\\\n<p>see <a href=\\\\\\"https://github.com/markdown-it/markdown-it-emoji#change-output\\\\\\">how to change output</a> with twemoji.</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-sub\\\\\\">Subscript</a> / <a href=\\\\\\"https://github.com/markdown-it/markdown-it-sup\\\\\\">Superscript</a></h3>\\\\n<ul>\\\\n<li>19^th^</li>\\\\n<li>H~2~O</li>\\\\n</ul>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-ins\\\\\\">\\\\\\\\<ins></a></h3>\\\\n<p>++Inserted text++</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-mark\\\\\\">\\\\\\\\<mark></a></h3>\\\\n<p>==Marked text==</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-footnote\\\\\\">Footnotes</a></h3>\\\\n<p>Footnote 1 link[^first].</p>\\\\n<p>Footnote 2 link[^second].</p>\\\\n<p>Inline footnote^[Text of inline footnote] definition.</p>\\\\n<p>Duplicated footnote reference[^second].</p>\\\\n<p>[^first]: Footnote <strong>can have markup</strong></p>\\\\n<pre><code>and multiple paragraphs.\\\\n</code></pre>\\\\n<p>[^second]: Footnote text.</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-deflist\\\\\\">Definition lists</a></h3>\\\\n<p>Term 1</p>\\\\n<p>:   Definition 1\\\\nwith lazy continuation.</p>\\\\n<p>Term 2 with <em>inline markup</em></p>\\\\n<p>:   Definition 2</p>\\\\n<pre><code>    { some code, part of Definition 2 }\\\\n\\\\nThird paragraph of definition 2.\\\\n</code></pre>\\\\n<p><em>Compact style:</em></p>\\\\n<p>Term 1\\\\n~ Definition 1</p>\\\\n<p>Term 2\\\\n~ Definition 2a\\\\n~ Definition 2b</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-abbr\\\\\\">Abbreviations</a></h3>\\\\n<p>This is HTML abbreviation example.</p>\\\\n<p>It converts \\\\\\"HTML\\\\\\", but keep intact partial entries like \\\\\\"xxxHTMLyyy\\\\\\" and so on.</p>\\\\n<p>*[HTML]: Hyper Text Markup Language</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-container\\\\\\">Custom containers</a></h3>\\\\n<p>::: warning\\\\n<em>here be dragons</em>\\\\n:::</p>\\\\n\\";"`;
+exports[`loader should work markdown -> html: md 1`] = `"module.exports = \\"<h1>h1 Heading 8-)</h1>\\\\n<h2>h2 Heading</h2>\\\\n<h3>h3 Heading</h3>\\\\n<h4>h4 Heading</h4>\\\\n<h5>h5 Heading</h5>\\\\n<h6>h6 Heading</h6>\\\\n<h2>Horizontal Rules</h2>\\\\n<hr>\\\\n<hr>\\\\n<hr>\\\\n<h2>Typographic replacements</h2>\\\\n<p>Enable typographer option to see result.</p>\\\\n<p>(c) (C) (r) (R) (tm) (TM) (p) (P) +-</p>\\\\n<p>test.. test... test..... test?..... test!....</p>\\\\n<p>!!!!!! ???? ,,  -- ---</p>\\\\n<p>\\\\\\"Smartypants, double quotes\\\\\\" and 'single quotes'</p>\\\\n<h2>Emphasis</h2>\\\\n<p><strong>This is bold text</strong></p>\\\\n<p><strong>This is bold text</strong></p>\\\\n<p><em>This is italic text</em></p>\\\\n<p><em>This is italic text</em></p>\\\\n<p><del>Strikethrough</del></p>\\\\n<h2>Blockquotes</h2>\\\\n<blockquote>\\\\n<p>Blockquotes can also be nested...</p>\\\\n<blockquote>\\\\n<p>...by using additional greater-than signs right next to each other...</p>\\\\n<blockquote>\\\\n<p>...or with spaces between arrows.</p>\\\\n</blockquote>\\\\n</blockquote>\\\\n</blockquote>\\\\n<h2>Lists</h2>\\\\n<p>Unordered</p>\\\\n<ul>\\\\n<li>Create a list by starting a line with <code>+</code>, <code>-</code>, or <code>*</code></li>\\\\n<li>Sub-lists are made by indenting 2 spaces:<ul>\\\\n<li>Marker character change forces new list start:<ul>\\\\n<li>Ac tristique libero volutpat at</li>\\\\n</ul><ul>\\\\n<li>Facilisis in pretium nisl aliquet</li>\\\\n</ul><ul>\\\\n<li>Nulla volutpat aliquam velit</li>\\\\n</ul></li>\\\\n</ul></li>\\\\n<li>Very easy!</li>\\\\n</ul>\\\\n<p>Ordered</p>\\\\n<ol>\\\\n<li>Lorem ipsum dolor sit amet</li>\\\\n<li>Consectetur adipiscing elit</li>\\\\n<li>Integer molestie lorem at massa</li>\\\\n</ol>\\\\n<ol>\\\\n<li>You can use sequential numbers...</li>\\\\n<li>...or keep all the numbers as <code>1.</code></li>\\\\n</ol>\\\\n<p>Start numbering with offset:</p>\\\\n<ol start=\\\\\\"57\\\\\\">\\\\n<li>foo</li>\\\\n<li>bar</li>\\\\n</ol>\\\\n<h2>Code</h2>\\\\n<p>Inline <code>code</code></p>\\\\n<p>Indented code</p>\\\\n<pre><code>// Some comments\\\\nline 1 of code\\\\nline 2 of code\\\\nline 3 of code\\\\n</code></pre>\\\\n<p>Block code \\\\\\"fences\\\\\\"</p>\\\\n<pre><code>Sample text here...\\\\n</code></pre>\\\\n<p>Syntax highlighting</p>\\\\n<pre><code class=\\\\\\"language-js\\\\\\">var foo = function (bar) {\\\\n  return bar++;\\\\n};\\\\n\\\\nconsole.log(foo(5));\\\\n</code></pre>\\\\n<h2>Tables</h2>\\\\n<table>\\\\n<thead>\\\\n<tr>\\\\n<th>Option</th>\\\\n<th>Description</th>\\\\n</tr>\\\\n</thead>\\\\n<tbody>\\\\n<tr>\\\\n<td>data</td>\\\\n<td>path to data files to supply the data that will be passed into templates.</td>\\\\n</tr>\\\\n<tr>\\\\n<td>engine</td>\\\\n<td>engine to be used for processing templates. Handlebars is the default.</td>\\\\n</tr>\\\\n<tr>\\\\n<td>ext</td>\\\\n<td>extension to be used for dest files.</td>\\\\n</tr>\\\\n</tbody>\\\\n</table>\\\\n<p>Right aligned columns</p>\\\\n<table>\\\\n<thead>\\\\n<tr>\\\\n<th align=\\\\\\"right\\\\\\">Option</th>\\\\n<th align=\\\\\\"right\\\\\\">Description</th>\\\\n</tr>\\\\n</thead>\\\\n<tbody>\\\\n<tr>\\\\n<td align=\\\\\\"right\\\\\\">data</td>\\\\n<td align=\\\\\\"right\\\\\\">path to data files to supply the data that will be passed into templates.</td>\\\\n</tr>\\\\n<tr>\\\\n<td align=\\\\\\"right\\\\\\">engine</td>\\\\n<td align=\\\\\\"right\\\\\\">engine to be used for processing templates. Handlebars is the default.</td>\\\\n</tr>\\\\n<tr>\\\\n<td align=\\\\\\"right\\\\\\">ext</td>\\\\n<td align=\\\\\\"right\\\\\\">extension to be used for dest files.</td>\\\\n</tr>\\\\n</tbody>\\\\n</table>\\\\n<h2>Links</h2>\\\\n<p><a href=\\\\\\"http://dev.nodeca.com\\\\\\">link text</a></p>\\\\n<p><a href=\\\\\\"http://nodeca.github.io/pica/demo/\\\\\\" title=\\\\\\"title text!\\\\\\">link with title</a></p>\\\\n<p>Autoconverted link <a href=\\\\\\"https://github.com/nodeca/pica\\\\\\">https://github.com/nodeca/pica</a> (enable linkify to see)</p>\\\\n<h2>Images</h2>\\\\n<p><img src=\\\\\\"https://octodex.github.com/images/minion.png\\\\\\" alt=\\\\\\"Minion\\\\\\">\\\\n<img src=\\\\\\"https://octodex.github.com/images/stormtroopocat.jpg\\\\\\" alt=\\\\\\"Stormtroopocat\\\\\\" title=\\\\\\"The Stormtroopocat\\\\\\"></p>\\\\n<p>Like links, Images also have a footnote style syntax</p>\\\\n<p><img src=\\\\\\"https://octodex.github.com/images/dojocat.jpg\\\\\\" alt=\\\\\\"Alt text\\\\\\" title=\\\\\\"The Dojocat\\\\\\"></p>\\\\n<p>With a reference later in the document defining the URL location:</p>\\\\n<h2>Plugins</h2>\\\\n<p>The killer feature of <code>markdown-it</code> is very effective support of\\\\n<a href=\\\\\\"https://www.npmjs.org/browse/keyword/markdown-it-plugin\\\\\\">syntax plugins</a>.</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-emoji\\\\\\">Emojies</a></h3>\\\\n<blockquote>\\\\n<p>Classic markup: :wink: :crush: :cry: :tear: :laughing: :yum:</p>\\\\n<p>Shortcuts (emoticons): :-) :-( 8-) ;)</p>\\\\n</blockquote>\\\\n<p>see <a href=\\\\\\"https://github.com/markdown-it/markdown-it-emoji#change-output\\\\\\">how to change output</a> with twemoji.</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-sub\\\\\\">Subscript</a> / <a href=\\\\\\"https://github.com/markdown-it/markdown-it-sup\\\\\\">Superscript</a></h3>\\\\n<ul>\\\\n<li>19^th^</li>\\\\n<li>H~2~O</li>\\\\n</ul>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-ins\\\\\\">\\\\\\\\<ins></a></h3>\\\\n<p>++Inserted text++</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-mark\\\\\\">\\\\\\\\<mark></a></h3>\\\\n<p>==Marked text==</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-footnote\\\\\\">Footnotes</a></h3>\\\\n<p>Footnote 1 link[^first].</p>\\\\n<p>Footnote 2 link[^second].</p>\\\\n<p>Inline footnote^[Text of inline footnote] definition.</p>\\\\n<p>Duplicated footnote reference[^second].</p>\\\\n<p>[^first]: Footnote <strong>can have markup</strong></p>\\\\n<pre><code>and multiple paragraphs.\\\\n</code></pre>\\\\n<p>[^second]: Footnote text.</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-deflist\\\\\\">Definition lists</a></h3>\\\\n<p>Term 1</p>\\\\n<p>:   Definition 1\\\\nwith lazy continuation.</p>\\\\n<p>Term 2 with <em>inline markup</em></p>\\\\n<p>:   Definition 2</p>\\\\n<pre><code>    { some code, part of Definition 2 }\\\\n\\\\nThird paragraph of definition 2.\\\\n</code></pre>\\\\n<p><em>Compact style:</em></p>\\\\n<p>Term 1\\\\n~ Definition 1</p>\\\\n<p>Term 2\\\\n~ Definition 2a\\\\n~ Definition 2b</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-abbr\\\\\\">Abbreviations</a></h3>\\\\n<p>This is HTML abbreviation example.</p>\\\\n<p>It converts \\\\\\"HTML\\\\\\", but keep intact partial entries like \\\\\\"xxxHTMLyyy\\\\\\" and so on.</p>\\\\n<p>*[HTML]: Hyper Text Markup Language</p>\\\\n<h3><a href=\\\\\\"https://github.com/markdown-it/markdown-it-container\\\\\\">Custom containers</a></h3>\\\\n<p>::: warning\\\\n<em>here be dragons</em>\\\\n:::</p>\\\\n\\";"`;
 
-exports[`loader should work: warnings 1`] = `Array []`;
+exports[`loader should work markdown -> html: warnings 1`] = `Array []`;
+
+exports[`loader should work markdown -> markdown: errors 1`] = `Array []`;
+
+exports[`loader should work markdown -> markdown: md 1`] = `
+"# h1 Heading 8-)
+
+## h2 Heading
+
+### h3 Heading
+
+#### h4 Heading
+
+##### h5 Heading
+
+###### h6 Heading
+
+## Horizontal Rules
+
+* * *
+
+* * *
+
+* * *
+
+## Typographic replacements
+
+Enable typographer option to see result.
+
+(c) (C) (r) (R) (tm) (TM) (p) (P) +-
+
+test.. test... test..... test?..... test!....
+
+!!!!!! ???? ,,  -- ---
+
+\\"Smartypants, double quotes\\" and 'single quotes'
+
+## Emphasis
+
+**This is bold text**
+
+**This is bold text**
+
+_This is italic text_
+
+_This is italic text_
+
+~~Strikethrough~~
+
+## Blockquotes
+
+> Blockquotes can also be nested...
+>
+> > ...by using additional greater-than signs right next to each other...
+> >
+> > > ...or with spaces between arrows.
+
+## Lists
+
+Unordered
+
+-   Create a list by starting a line with \`+\`, \`-\`, or \`*\`
+-   Sub-lists are made by indenting 2 spaces:
+    -   Marker character change forces new list start:
+        -   Ac tristique libero volutpat at
+        -   Facilisis in pretium nisl aliquet
+        -   Nulla volutpat aliquam velit
+-   Very easy!
+
+Ordered
+
+1.  Lorem ipsum dolor sit amet
+2.  Consectetur adipiscing elit
+3.  Integer molestie lorem at massa
+
+
+1.  You can use sequential numbers...
+2.  ...or keep all the numbers as \`1.\`
+
+Start numbering with offset:
+
+57. foo
+58. bar
+
+## Code
+
+Inline \`code\`
+
+Indented code
+
+    // Some comments
+    line 1 of code
+    line 2 of code
+    line 3 of code
+
+Block code \\"fences\\"
+
+    Sample text here...
+
+Syntax highlighting
+
+\`\`\`js
+var foo = function (bar) {
+  return bar++;
+};
+
+console.log(foo(5));
+\`\`\`
+
+## Tables
+
+| Option | Description                                                               |
+| ------ | ------------------------------------------------------------------------- |
+| data   | path to data files to supply the data that will be passed into templates. |
+| engine | engine to be used for processing templates. Handlebars is the default.    |
+| ext    | extension to be used for dest files.                                      |
+
+Right aligned columns
+
+| Option |                                                               Description |
+| -----: | ------------------------------------------------------------------------: |
+|   data | path to data files to supply the data that will be passed into templates. |
+| engine |    engine to be used for processing templates. Handlebars is the default. |
+|    ext |                                      extension to be used for dest files. |
+
+## Links
+
+[link text](http://dev.nodeca.com)
+
+[link with title](http://nodeca.github.io/pica/demo/ \\"title text!\\")
+
+Autoconverted link <https://github.com/nodeca/pica> (enable linkify to see)
+
+## Images
+
+![Minion](https://octodex.github.com/images/minion.png)
+![Stormtroopocat](https://octodex.github.com/images/stormtroopocat.jpg \\"The Stormtroopocat\\")
+
+Like links, Images also have a footnote style syntax
+
+![Alt text][id]
+
+With a reference later in the document defining the URL location:
+
+[id]: https://octodex.github.com/images/dojocat.jpg \\"The Dojocat\\"
+
+## Plugins
+
+The killer feature of \`markdown-it\` is very effective support of
+[syntax plugins](https://www.npmjs.org/browse/keyword/markdown-it-plugin).
+
+### [Emojies](https://github.com/markdown-it/markdown-it-emoji)
+
+> Classic markup: :wink: :crush: :cry: :tear: :laughing: :yum:
+>
+> Shortcuts (emoticons): :-) :-( 8-) ;)
+
+see [how to change output](https://github.com/markdown-it/markdown-it-emoji#change-output) with twemoji.
+
+### [Subscript](https://github.com/markdown-it/markdown-it-sub) / [Superscript](https://github.com/markdown-it/markdown-it-sup)
+
+-   19^th^
+-   H~2~O
+
+### [\\\\\\\\<ins>](https://github.com/markdown-it/markdown-it-ins)
+
+\\\\++Inserted text++
+
+### [\\\\\\\\<mark>](https://github.com/markdown-it/markdown-it-mark)
+
+==Marked text==
+
+### [Footnotes](https://github.com/markdown-it/markdown-it-footnote)
+
+Footnote 1 link[^first].
+
+Footnote 2 link[^second].
+
+Inline footnote^[Text of inline footnote] definition.
+
+Duplicated footnote reference[^second].
+
+[^first]&#x3A; Footnote **can have markup**
+
+    and multiple paragraphs.
+
+[^second]&#x3A; Footnote text.
+
+### [Definition lists](https://github.com/markdown-it/markdown-it-deflist)
+
+Term 1
+
+:   Definition 1
+with lazy continuation.
+
+Term 2 with _inline markup_
+
+:   Definition 2
+
+        { some code, part of Definition 2 }
+
+    Third paragraph of definition 2.
+
+_Compact style:_
+
+Term 1
+  ~ Definition 1
+
+Term 2
+  ~ Definition 2a
+  ~ Definition 2b
+
+### [Abbreviations](https://github.com/markdown-it/markdown-it-abbr)
+
+This is HTML abbreviation example.
+
+It converts \\"HTML\\", but keep intact partial entries like \\"xxxHTMLyyy\\" and so on.
+
+\\\\*[HTML]&#x3A; Hyper Text Markup Language
+
+### [Custom containers](https://github.com/markdown-it/markdown-it-container)
+
+::: warning
+_here be dragons_
+:::
+"
+`;
+
+exports[`loader should work markdown -> markdown: warnings 1`] = `Array []`;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -1,3 +1,7 @@
+import path from 'path';
+
+import RemarkHTML from 'remark-html';
+
 import {
   compile,
   getExecutedCode,
@@ -7,11 +11,48 @@ import {
 } from './helpers';
 
 describe('loader', () => {
-  it('should work', async () => {
+  it('should work markdown -> markdown', async () => {
     const compiler = getCompiler('simple.js', {
       // eslint-disable-next-line global-require
       plugins: [require('remark-kbd')],
     });
+    const stats = await compile(compiler);
+    const codeFromBundle = getExecutedCode('main.bundle.js', compiler, stats);
+
+    expect(codeFromBundle.md).toMatchSnapshot('md');
+    expect(getErrors(stats)).toMatchSnapshot('errors');
+    expect(getWarnings(stats)).toMatchSnapshot('warnings');
+  });
+
+  it('should work markdown -> html', async () => {
+    const compiler = getCompiler(
+      'simple.js',
+      {},
+      {
+        module: {
+          rules: [
+            {
+              test: /\.md$/i,
+              rules: [
+                {
+                  loader: require.resolve('./helpers/testLoader'),
+                },
+                {
+                  loader: 'html-loader',
+                },
+                {
+                  loader: path.resolve(__dirname, '../src'),
+                  options: {
+                    // eslint-disable-next-line global-require
+                    plugins: [require('remark-kbd'), RemarkHTML],
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }
+    );
     const stats = await compile(compiler);
     const codeFromBundle = getExecutedCode('main.bundle.js', compiler, stats);
 


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [ ] new **feature**
- [x] **code refactor**
- [x] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

Remove html loader from remark loader

### Breaking Changes

To get html, need to add `remark-html` to the remark plugins and add html loader to the webpack config

### Additional Info

No
